### PR TITLE
Update collection plugin to use plugin configuration system

### DIFF
--- a/src/Jellyfin.Plugin.CollectionSections/CollectionSectionPlugin.cs
+++ b/src/Jellyfin.Plugin.CollectionSections/CollectionSectionPlugin.cs
@@ -34,7 +34,40 @@ namespace Jellyfin.Plugin.CollectionSections
             ConfigurationChanged += OnConfigurationChanged;
         }
 
-        internal void OnConfigurationChanged(object? sender, BasePluginConfiguration e)
+        /// <summary>
+        /// Waits for Home Screen plugin readiness with exponential backoff.
+        /// </summary>
+        private async Task<bool> WaitForHomeScreenReady(HttpClient client, int maxAttempts = 12, int initialDelayMs = 250)
+        {
+            for (int attempt = 1; attempt <= maxAttempts; attempt++)
+            {
+                try
+                {
+                    var response = await client.GetAsync("/HomeScreen/Ready");
+                    if (response.IsSuccessStatusCode)
+                    {
+                        m_logger.LogInformation("Home Screen plugin ready (attempt {Attempt})", attempt);
+                        return true;
+                    }
+                    
+                    m_logger.LogDebug("Home Screen not ready (attempt {Attempt}/{Max}): {Status}", 
+                        attempt, maxAttempts, response.StatusCode);
+                }
+                catch (Exception ex)
+                {
+                    m_logger.LogDebug("Readiness check failed (attempt {Attempt}/{Max}): {Error}", 
+                        attempt, maxAttempts, ex.Message);
+                }
+                               
+                // Exponential backoff: 250ms → 8s max
+                int delayMs = Math.Min(initialDelayMs * (1 << (attempt - 1)), 8000);
+                await Task.Delay(delayMs);
+            }
+            
+            return false;
+        }
+
+        internal async void OnConfigurationChanged(object? sender, BasePluginConfiguration e)
         {
             if (e is PluginConfiguration pluginConfiguration)
             {
@@ -44,6 +77,12 @@ namespace Jellyfin.Plugin.CollectionSections
                 HttpClient client = new HttpClient();
                 client.BaseAddress = new Uri(publishedServerUrl ?? $"http://localhost:{m_serverApplicationHost.HttpPort}");
 
+                if (!await WaitForHomeScreenReady(client))
+                {
+                    m_logger.LogError("Home Screen plugin not ready after {MaxWait}s. Cannot register sections.", 96);
+                    return;
+                }
+
                 foreach (SectionsConfig section in pluginConfiguration.Sections)
                 {
                     JObject jsonPayload = new JObject();
@@ -51,6 +90,95 @@ namespace Jellyfin.Plugin.CollectionSections
                     jsonPayload.Add("displayText", section.DisplayText);
                     jsonPayload.Add("limit", 1);
                     jsonPayload.Add("additionalData", section.CollectionName);
+
+                    JObject info = new JObject
+                    {
+                        ["description"] = string.IsNullOrEmpty(section.Description) 
+                            ? $"Display items from the {section.CollectionName} {section.SectionType.ToString().ToLower()}"
+                            : section.Description,
+                        ["adminNotes"] = "This section is managed by the Collection Sections plugin. Configure the source collection/playlist and display options in the Collection Sections plugin settings.",
+                        ["versionControl"] = new JObject
+                        {
+                            ["platform"] = "GitHub",
+                            ["username"] = "IAmParadox27",
+                            ["repository"] = "jellyfin-plugin-collection-sections",
+                            ["includeIssuesLink"] = true,
+                            ["featureRequestTag"] = "collection-sections"
+                        }
+                    };
+                    jsonPayload.Add("info", info);
+
+                    JArray configurationOptions = new JArray();
+                    
+                    JObject sortOrderOption = new JObject
+                    {
+                        ["key"] = "sortOrder",
+                        ["name"] = "Sort Order",
+                        ["description"] = "How to sort the items",
+                        ["type"] = "dropdown",
+                        ["defaultValue"] = "Default",
+                        ["allowUserOverride"] = true,
+                        ["options"] = new JArray(
+                            new JObject { ["key"] = "Default", ["value"] = "Default" },
+                            new JObject { ["key"] = "DateAdded", ["value"] = "Date Added To Server" },
+                            new JObject { ["key"] = "Alphabetical", ["value"] = "Alphabetical" },
+                            new JObject { ["key"] = "Random", ["value"] = "Random" },
+                            new JObject { ["key"] = "CommunityRating", ["value"] = "Rating" },
+                            new JObject { ["key"] = "PremiereDate", ["value"] = "Release Date" },
+                            new JObject { ["key"] = "RecentlyWatched", ["value"] = "Recently Watched" }
+                        )
+                    };
+                    configurationOptions.Add(sortOrderOption);
+
+                    JObject sortDirectionOption = new JObject
+                    {
+                        ["key"] = "sortDirection",
+                        ["name"] = "Sort Direction",
+                        ["description"] = "Direction for sorting",
+                        ["type"] = "dropdown",
+                        ["defaultValue"] = "Descending",
+                        ["allowUserOverride"] = true,
+                        ["options"] = new JArray(
+                            new JObject { ["key"] = "Ascending", ["value"] = "Ascending (A-Z, Oldest First)" },
+                            new JObject { ["key"] = "Descending", ["value"] = "Descending (Z-A, Newest First)" }
+                        )
+                    };
+                    configurationOptions.Add(sortDirectionOption);
+
+                    JObject watchedItemsOption = new JObject
+                    {
+                        ["key"] = "watchedItemsHandling",
+                        ["name"] = "Watched Items Handling",
+                        ["description"] = "How to handle items that have been watched",
+                        ["type"] = "dropdown",
+                        ["defaultValue"] = "Show",
+                        ["allowUserOverride"] = true,
+                        ["advanced"] = true,
+                        ["options"] = new JArray(
+                            new JObject { ["key"] = "Show", ["value"] = "Show" },
+                            new JObject { ["key"] = "Hide", ["value"] = "Hide" }
+                        )
+                    };
+                    configurationOptions.Add(watchedItemsOption);
+
+                    JObject itemLimitOption = new JObject
+                    {
+                        ["key"] = "itemLimit",
+                        ["name"] = "Item Limit",
+                        ["description"] = "Maximum number of items to display",
+                        ["type"] = "numberbox",
+                        ["defaultValue"] = 32.0,
+                        ["allowUserOverride"] = true,
+                        ["advanced"] = true,
+                        ["validation"] = new JObject
+                        {
+                            ["min"] = 1,
+                            ["max"] = 100
+                        }
+                    };
+                    configurationOptions.Add(itemLimitOption);
+
+                    jsonPayload.Add("configurationOptions", configurationOptions.ToString());
 
                     if (section.SectionType == SectionType.Collection)
                     {
@@ -63,9 +191,19 @@ namespace Jellyfin.Plugin.CollectionSections
 
                     try
                     {
-                        client.PostAsync("/HomeScreen/RegisterSection",
+                        var response = await client.PostAsync("/HomeScreen/RegisterSection",
                             new StringContent(jsonPayload.ToString(Formatting.None),
-                                MediaTypeHeaderValue.Parse("application/json"))).GetAwaiter().GetResult();
+                                MediaTypeHeaderValue.Parse("application/json")));
+                        
+                        if (response.IsSuccessStatusCode)
+                        {
+                            m_logger.LogInformation("Registered section '{DisplayText}'", section.DisplayText);
+                        }
+                        else
+                        {
+                            m_logger.LogWarning("Failed to register section '{DisplayText}': {StatusCode}", 
+                                section.DisplayText, response.StatusCode);
+                        }
                     }
                     catch (Exception ex)
                     {

--- a/src/Jellyfin.Plugin.CollectionSections/Configuration/SectionsConfig.cs
+++ b/src/Jellyfin.Plugin.CollectionSections/Configuration/SectionsConfig.cs
@@ -1,4 +1,6 @@
-﻿namespace Jellyfin.Plugin.CollectionSections.Configuration
+﻿using System.Text.Json.Serialization;
+
+namespace Jellyfin.Plugin.CollectionSections.Configuration
 {
     public enum SectionType
     {
@@ -12,5 +14,10 @@
         public required string DisplayText { get; set; }
         public required string CollectionName { get; set; }
         public SectionType SectionType { get; set; }
+        public string? Description { get; set; }
+        public double MaxItems { get; set; } = 32.0;
+        public bool ShowOnlyUnwatched { get; set; } = false;
+        public string? SortBy { get; set; } = "Default";
+        public bool SortDescending { get; set; } = true;
     }
 }

--- a/src/Jellyfin.Plugin.CollectionSections/Configuration/config.html
+++ b/src/Jellyfin.Plugin.CollectionSections/Configuration/config.html
@@ -43,6 +43,11 @@
                 <span>The heading that will display on the home screen.</span>
             </div>
             <div class="inputContainer">
+                <input is="emby-input" type="text" data-id="txtDescription"
+                       label="Description (Optional):" />
+                <span>A description for this section that will appear to users in the settings.</span>
+            </div>
+            <div class="inputContainer">
                 <span>Collection Type: </span>
                 <select is="emby-select" class="emby-select-withcolor emby-select" data-id="collectTypeSelect">
                     <option value="Collection">Collection</option>
@@ -76,6 +81,7 @@
                     const template = CollectionSections.template.cloneNode(true).content;
                     template.querySelector("[data-id=txtUniqueId]").value = set.UniqueId || "";
                     template.querySelector("[data-id=txtDisplayText]").value = set.DisplayText || "";
+                    template.querySelector("[data-id=txtDescription]").value = set.Description || "";
                     template.querySelector("[data-id=txtCollectionName]").value = set.CollectionName || "";
                     template.querySelector("[data-id=collectTypeSelect]").value = set.SectionType;
 
@@ -85,8 +91,10 @@
                     const set = {
                         UniqueId: "CHANGE_ME",
                         DisplayText: "<Section Name>",
+                        Description: "",
                         CollectionName: "",
-                        SectionType: "Collection"
+                        SectionType: "Collection",
+                        EnableByDefault: true
                     };
                     CollectionSections.addSet(set);
                 },
@@ -107,6 +115,7 @@
                         const repo = {
                             UniqueId: configs[i].querySelector("[data-id=txtUniqueId]").value,
                             DisplayText: configs[i].querySelector("[data-id=txtDisplayText]").value,
+                            Description: configs[i].querySelector("[data-id=txtDescription]").value,
                             CollectionName: configs[i].querySelector("[data-id=txtCollectionName]").value,
                             SectionType: configs[i].querySelector("[data-id=collectTypeSelect]").value
                         };

--- a/src/Jellyfin.Plugin.CollectionSections/Controllers/CollectionSectionsController.cs
+++ b/src/Jellyfin.Plugin.CollectionSections/Controllers/CollectionSectionsController.cs
@@ -1,5 +1,6 @@
 ﻿using Jellyfin.Plugin.CollectionSections.Extensions;
 using Jellyfin.Plugin.CollectionSections.Model;
+using Jellyfin.Plugin.CollectionSections.Configuration;
 using MediaBrowser.Controller.Collections;
 using MediaBrowser.Controller.Dto;
 using MediaBrowser.Controller.Entities;
@@ -11,9 +12,30 @@ using MediaBrowser.Model.Dto;
 using MediaBrowser.Model.Entities;
 using MediaBrowser.Model.Querying;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Primitives;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace Jellyfin.Plugin.CollectionSections.Controllers
 {
+    /// <summary>
+    /// Configuration for collection sections.
+    /// </summary>
+    public class CollectionSectionConfig
+    {
+        [JsonPropertyName("itemLimit")]
+        public double ItemLimit { get; set; } = 32.0;
+        
+        [JsonPropertyName("watchedItemsHandling")]
+        public string WatchedItemsHandling { get; set; } = "Show";
+        
+        [JsonPropertyName("sortOrder")]
+        public string SortOrder { get; set; } = "Default";
+        
+        [JsonPropertyName("sortDirection")]
+        public string SortDirection { get; set; } = "Descending";
+    }
+
     [Route("[controller]")]
     public class CollectionSectionsController : ControllerBase
     {
@@ -21,14 +43,16 @@ namespace Jellyfin.Plugin.CollectionSections.Controllers
         private readonly IPlaylistManager m_playlistManager;
         private readonly IDtoService m_dtoService;
         private readonly IUserManager m_userManager;
+        private readonly IUserDataManager m_userDataManager;
 
         public CollectionSectionsController(ICollectionManager collectionManager, IPlaylistManager playlistManager, 
-            IUserManager userManager, IDtoService dtoService)
+            IUserManager userManager, IDtoService dtoService, IUserDataManager userDataManager)
         {
             m_collectionManager = collectionManager;
             m_playlistManager = playlistManager;
             m_dtoService = dtoService;
             m_userManager = userManager;
+            m_userDataManager = userDataManager;
         }
         
         [HttpPost("Collection")]
@@ -55,10 +79,14 @@ namespace Jellyfin.Plugin.CollectionSections.Controllers
             BoxSet? collection = m_collectionManager.GetCollections(user)
                 .FirstOrDefault(x => x.Name == payload.AdditionalData);
         
-            List<BaseItem> items =  collection?.GetChildren(user, true).ToList() ?? new List<BaseItem>();
+            if (collection == null)
+            {
+                return new QueryResult<BaseItemDto>();
+            }
+
+            List<BaseItem> items = collection.GetChildren(user, true).ToList();
+            items = ApplyUserConfiguration(items, payload, user);
             
-            items = items.Take(Math.Min(items.Count, 32)).ToList();
-        
             return new QueryResult<BaseItemDto>(m_dtoService.GetBaseItemDtos(items, dtoOptions, user));
         }
         
@@ -82,11 +110,17 @@ namespace Jellyfin.Plugin.CollectionSections.Controllers
                 ImageTypeLimit = 1
             };
 
+            User user = m_userManager.GetUserById(payload.UserId)!;
             Playlist? playlist = m_playlistManager.GetPlaylists(payload.UserId)
                 .FirstOrDefault(x => x.Name == payload.AdditionalData);
 
-            IEnumerable<Tuple<LinkedChild, BaseItem>> itemsRaw = playlist?.GetManageableItems()
-                .Where(i => i.Item2.IsVisible(m_userManager.GetUserById(payload.UserId))) ?? Enumerable.Empty<Tuple<LinkedChild, BaseItem>>();
+            if (playlist == null)
+            {
+                return new QueryResult<BaseItemDto>();
+            }
+
+            IEnumerable<Tuple<LinkedChild, BaseItem>> itemsRaw = playlist.GetManageableItems()
+                .Where(i => i.Item2.IsVisible(user));
 
             IEnumerable<IGrouping<BaseItem, Tuple<LinkedChild, BaseItem>>> groupedItems = itemsRaw.GroupBy(x =>
             {
@@ -98,10 +132,97 @@ namespace Jellyfin.Plugin.CollectionSections.Controllers
                 return x.Item2;
             });
         
-            IGrouping<BaseItem, Tuple<LinkedChild, BaseItem>>[] items = groupedItems.Take(Math.Min(groupedItems.Count(), 32)).ToArray();
+            List<BaseItem> items = groupedItems.Select(x => x.Key).ToList();
+            items = ApplyUserConfiguration(items, payload, user);
         
-            User user = m_userManager.GetUserById(payload.UserId)!;
-            return new QueryResult<BaseItemDto>(m_dtoService.GetBaseItemDtos(items.Select(x => x.Key).ToList(), dtoOptions, user));
+            return new QueryResult<BaseItemDto>(m_dtoService.GetBaseItemDtos(items, dtoOptions, user));
+        }
+
+        private List<BaseItem> ApplyUserConfiguration(List<BaseItem> items, HomeScreenSectionPayload payload, User user)
+        {
+            var config = ParseConfiguration(payload);
+
+            if (config.WatchedItemsHandling == "Hide")
+            {
+                items = items.Where(item => !item.IsPlayed(user)).ToList();
+            }
+
+            items = ApplySortingToItems(items, config.SortOrder, config.SortDirection, user).ToList();
+            items = items.Take(Math.Min(items.Count, (int)config.ItemLimit)).ToList();
+
+            return items;
+        }
+
+        /// <summary>
+        /// Parses configuration from payload.
+        /// </summary>
+        private CollectionSectionConfig ParseConfiguration(HomeScreenSectionPayload payload)
+        {
+            var config = new CollectionSectionConfig();
+            
+            if (payload.UserConfiguration != null)
+            {
+                try
+                {
+                    var json = JsonSerializer.Serialize(payload.UserConfiguration);
+                    var parsed = JsonSerializer.Deserialize<CollectionSectionConfig>(json);
+                    if (parsed != null) 
+                    {
+                        return parsed;
+                    }
+                }
+                catch (JsonException)
+                {
+                }
+            }
+            
+            return config;
+        }
+
+        /// <summary>
+        /// Applies sorting to items.
+        /// </summary>
+        private IEnumerable<BaseItem> ApplySortingToItems(IEnumerable<BaseItem> items, string sortOrder, string sortDirection, User user)
+        {
+            var sortedItems = sortOrder switch
+            {
+                "Default" => items,
+                "PremiereDate" => items.OrderBy(item => item.PremiereDate ?? DateTime.MinValue),
+                "DateAdded" => items.OrderBy(item => item.DateCreated),
+                "Alphabetical" => items.OrderBy(item => item.SortName ?? item.Name),
+                "RecentlyWatched" => GetRecentlyWatchedSortedItems(items, user),
+                "CommunityRating" => items.OrderBy(item => item.CommunityRating ?? 0),
+                "Random" => items.OrderBy(x => Random.Shared.Next()),
+                _ => items
+            };
+
+            if (string.Equals(sortDirection, "Descending", StringComparison.OrdinalIgnoreCase))
+            {
+                sortedItems = sortedItems.Reverse();
+            }
+
+            return sortedItems;
+        }
+
+        private IEnumerable<BaseItem> GetRecentlyWatchedSortedItems(IEnumerable<BaseItem> items, User user)
+        {
+            var itemsList = items.ToList();
+            var userDataLookup = new Dictionary<Guid, DateTime>();
+            
+            foreach (var item in itemsList)
+            {
+                try
+                {
+                    var userData = m_userDataManager.GetUserData(user, item);
+                    userDataLookup[item.Id] = userData?.LastPlayedDate ?? DateTime.MinValue;
+                }
+                catch
+                {
+                    userDataLookup[item.Id] = DateTime.MinValue;
+                }
+            }
+            
+            return itemsList.OrderBy(item => userDataLookup[item.Id]);
         }
     }
 }

--- a/src/Jellyfin.Plugin.CollectionSections/Model/HomeScreenSectionPayload.cs
+++ b/src/Jellyfin.Plugin.CollectionSections/Model/HomeScreenSectionPayload.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Jellyfin.Plugin.CollectionSections.Model
 {
     
@@ -8,12 +10,17 @@ namespace Jellyfin.Plugin.CollectionSections.Model
         
         
         
+        [JsonPropertyName("userId")]
         public Guid UserId { get; set; }
 
         
         
         
         
+        [JsonPropertyName("additionalData")]
         public string? AdditionalData { get; set; }
+
+        [JsonPropertyName("userConfiguration")]
+        public Dictionary<string, object>? UserConfiguration { get; set; }
     }
 }


### PR DESCRIPTION
Requires the changes in [jellyfin-plugin-home-sections PR](https://github.com/IAmParadox27/jellyfin-plugin-home-sections/pull/70)  

This PR adds section info as well as new configurations for:
- **Sort Order** - Default, Date Added, Alphabetical, Random, Rating, Release Date, Recently Watched
- **Sort Direction** - Ascending or Descending  
- **Watched Items Handling** - Show or Hide watched content
- **Item Limit** - Maximum number of items to display (1-100)
In addition the synthetic options "Custom Display Name" and "Section Header Display" are automatically added without any changes from the collections plugin.

It also uses a new `/HomeScreen/Ready` which resolves https://github.com/IAmParadox27/jellyfin-plugin-collection-sections/issues/4
